### PR TITLE
Compatible with Crystal 0.19.0

### DIFF
--- a/src/singleton.cr
+++ b/src/singleton.cr
@@ -19,6 +19,6 @@ class Singleton
       @@instances[t.name] = GenericProducer(T).new(t.new)
     end
 
-    @@instances[t.name].produce as T
+    @@instances[t.name].produce.as T
   end
 end


### PR DESCRIPTION
Compatible with breaking change of syntax at Crystal 0.19.0.

https://github.com/crystal-lang/crystal/blob/0.19.0/CHANGELOG.md#0190

> (breaking change) Removed the deprecated syntax x as T
